### PR TITLE
split out gostring test into new test function

### DIFF
--- a/unit_test.go
+++ b/unit_test.go
@@ -21,7 +21,6 @@ var formatTests = []struct {
 	{New(9.81, Dimensions{MassDim: 1, TimeDim: -2, LengthDim: 0}), "%f", "9.81 kg s^-2"},
 	{New(6.62606957e-34, Dimensions{MassDim: 2, TimeDim: -1}), "%e", "6.62606957e-34 kg^2 s^-1"},
 	{New(6.62606957e-34, Dimensions{MassDim: 2, TimeDim: -1}), "%.3e", "6.626e-34 kg^2 s^-1"},
-	{New(6.62606957e-34, Dimensions{MassDim: 2, TimeDim: -1}), "%#v", `&unit.Unit{dimensions:unit.Dimensions{4:2, 6:-1}, formatted:"", value:6.62606957e-34}`},
 	{New(6.62606957e-34, Dimensions{MassDim: 2, TimeDim: -1}), "%v", "6.62606957e-34 kg^2 s^-1"},
 	{New(6.62606957e-34, Dimensions{MassDim: 2, TimeDim: -1}), "%s", "%!s(*Unit=6.62606957e-34 kg^2 s^-1)"},
 	{Dimless(math.E), "%v", "2.718281828459045"},
@@ -43,6 +42,14 @@ func TestFormat(t *testing.T) {
 		if r := fmt.Sprintf(ts.format, ts.unit); r != ts.expect {
 			t.Errorf("Format %q: got: %q expected: %q", ts.format, r, ts.expect)
 		}
+	}
+}
+
+func TestGoStringFormat(t *testing.T) {
+	expect1 := `&unit.Unit{dimensions:unit.Dimensions{4:2, 6:-1}, formatted:"", value:6.62606957e-34}`
+	expect2 := `&unit.Unit{dimensions:unit.Dimensions{6:-1, 4:2}, formatted:"", value:6.62606957e-34}`
+	if r := fmt.Sprintf("%#v", New(6.62606957e-34, Dimensions{MassDim: 2, TimeDim: -1})); r != expect1 && r != expect2 {
+		t.Errorf("Format %q: got: %q expected: %q", "%#v", r, expect1)
 	}
 }
 


### PR DESCRIPTION
unit.Unit has a map for the dimensions, so the gostring for units with
multiple dimensions has multiple possible values.  I split out the only
multidimensional test to a new function.
