### PR TITLE
only run coverage when api key is available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
  - go build -v ./...
  - go test -v ./...
  - diff <(gofmt -d .) <("")
- - bash test-coverage.sh
+ - if [[ $TRAVIS_SECURE_ENV_VARS = "true" ]]; then bash test-coverage.sh; fi
 
 after_failure: failure
 


### PR DESCRIPTION
The api key for coverage is only available when merging a gonum branch,
not a fork.  This changes the travis instructions to still run tests
when coverage is not possible.
