### PR TITLE
unit: fix width/precision handling

### DIFF
--- a/dimless.go
+++ b/dimless.go
@@ -48,14 +48,17 @@ func (d Dimless) Format(fs fmt.State, c rune) {
 		fallthrough
 	case 'e', 'E', 'f', 'F', 'g', 'G':
 		p, pOk := fs.Precision()
-		if !pOk {
-			p = -1
-		}
 		w, wOk := fs.Width()
-		if !wOk {
-			w = -1
+		switch {
+		case pOk && wOk:
+			fmt.Fprintf(fs, "%*.*"+string(c), w, p, float64(d))
+		case pOk:
+			fmt.Fprintf(fs, "%.*"+string(c), p, float64(d))
+		case wOk:
+			fmt.Fprintf(fs, "%*"+string(c), w, float64(d))
+		default:
+			fmt.Fprintf(fs, "%"+string(c), float64(d))
 		}
-		fmt.Fprintf(fs, "%*.*"+string(c), w, p, float64(d))
 	default:
 		fmt.Fprintf(fs, "%%!%c(%T=%g)", c, d, float64(d))
 		return

--- a/length.go
+++ b/length.go
@@ -73,14 +73,17 @@ func (l Length) Format(fs fmt.State, c rune) {
 		fallthrough
 	case 'e', 'E', 'f', 'F', 'g', 'G':
 		p, pOk := fs.Precision()
-		if !pOk {
-			p = -1
-		}
 		w, wOk := fs.Width()
-		if !wOk {
-			w = -1
+		switch {
+		case pOk && wOk:
+			fmt.Fprintf(fs, "%*.*"+string(c), w, p, float64(l))
+		case pOk:
+			fmt.Fprintf(fs, "%.*"+string(c), p, float64(l))
+		case wOk:
+			fmt.Fprintf(fs, "%*"+string(c), w, float64(l))
+		default:
+			fmt.Fprintf(fs, "%"+string(c), float64(l))
 		}
-		fmt.Fprintf(fs, "%*.*"+string(c), w, p, float64(l))
 		fmt.Fprint(fs, " m")
 	default:
 		fmt.Fprintf(fs, "%%!%c(%T=%g m)", c, l, float64(l))

--- a/mass.go
+++ b/mass.go
@@ -73,14 +73,17 @@ func (m Mass) Format(fs fmt.State, c rune) {
 		fallthrough
 	case 'e', 'E', 'f', 'F', 'g', 'G':
 		p, pOk := fs.Precision()
-		if !pOk {
-			p = -1
-		}
 		w, wOk := fs.Width()
-		if !wOk {
-			w = -1
+		switch {
+		case pOk && wOk:
+			fmt.Fprintf(fs, "%*.*"+string(c), w, p, float64(m))
+		case pOk:
+			fmt.Fprintf(fs, "%.*"+string(c), p, float64(m))
+		case wOk:
+			fmt.Fprintf(fs, "%*"+string(c), w, float64(m))
+		default:
+			fmt.Fprintf(fs, "%"+string(c), float64(m))
 		}
-		fmt.Fprintf(fs, "%*.*"+string(c), w, p, float64(m))
 		fmt.Fprint(fs, " kg")
 	default:
 		fmt.Fprintf(fs, "%%!%c(%T=%g kg)", c, m, float64(m))

--- a/time.go
+++ b/time.go
@@ -76,14 +76,17 @@ func (t Time) Format(fs fmt.State, c rune) {
 		fallthrough
 	case 'e', 'E', 'f', 'F', 'g', 'G':
 		p, pOk := fs.Precision()
-		if !pOk {
-			p = -1
-		}
 		w, wOk := fs.Width()
-		if !wOk {
-			w = -1
+		switch {
+		case pOk && wOk:
+			fmt.Fprintf(fs, "%*.*"+string(c), w, p, float64(t))
+		case pOk:
+			fmt.Fprintf(fs, "%.*"+string(c), p, float64(t))
+		case wOk:
+			fmt.Fprintf(fs, "%*"+string(c), w, float64(t))
+		default:
+			fmt.Fprintf(fs, "%"+string(c), float64(t))
 		}
-		fmt.Fprintf(fs, "%*.*"+string(c), w, p, float64(t))
 		fmt.Fprint(fs, " s")
 	default:
 		fmt.Fprintf(fs, "%%!%c(%T=%g s)", c, t, float64(t))

--- a/unit_test.go
+++ b/unit_test.go
@@ -15,11 +15,11 @@ var formatTests = []struct {
 	format string
 	expect string
 }{
-	{New(9.81, Dimensions{MassDim: 1, TimeDim: -2}), "%f", "9.81 kg s^-2"},
+	{New(9.81, Dimensions{MassDim: 1, TimeDim: -2}), "%f", "9.810000 kg s^-2"},
 	{New(9.81, Dimensions{MassDim: 1, TimeDim: -2}), "%1.f", "10 kg s^-2"},
 	{New(9.81, Dimensions{MassDim: 1, TimeDim: -2}), "%.1f", "9.8 kg s^-2"},
-	{New(9.81, Dimensions{MassDim: 1, TimeDim: -2, LengthDim: 0}), "%f", "9.81 kg s^-2"},
-	{New(6.62606957e-34, Dimensions{MassDim: 2, TimeDim: -1}), "%e", "6.62606957e-34 kg^2 s^-1"},
+	{New(9.81, Dimensions{MassDim: 1, TimeDim: -2, LengthDim: 0}), "%f", "9.810000 kg s^-2"},
+	{New(6.62606957e-34, Dimensions{MassDim: 2, TimeDim: -1}), "%e", "6.626070e-34 kg^2 s^-1"},
 	{New(6.62606957e-34, Dimensions{MassDim: 2, TimeDim: -1}), "%.3e", "6.626e-34 kg^2 s^-1"},
 	{New(6.62606957e-34, Dimensions{MassDim: 2, TimeDim: -1}), "%v", "6.62606957e-34 kg^2 s^-1"},
 	{New(6.62606957e-34, Dimensions{MassDim: 2, TimeDim: -1}), "%s", "%!s(*Unit=6.62606957e-34 kg^2 s^-1)"},

--- a/unittype.go
+++ b/unittype.go
@@ -327,14 +327,17 @@ func (u *Unit) Format(fs fmt.State, c rune) {
 		fallthrough
 	case 'e', 'E', 'f', 'F', 'g', 'G':
 		p, pOk := fs.Precision()
-		if !pOk {
-			p = -1
-		}
 		w, wOk := fs.Width()
-		if !wOk {
-			w = -1
+		switch {
+		case pOk && wOk:
+			fmt.Fprintf(fs, "%*.*"+string(c), w, p, u.value)
+		case pOk:
+			fmt.Fprintf(fs, "%.*"+string(c), p, u.value)
+		case wOk:
+			fmt.Fprintf(fs, "%*"+string(c), w, u.value)
+		default:
+			fmt.Fprintf(fs, "%"+string(c), u.value)
 		}
-		fmt.Fprintf(fs, "%*.*"+string(c), w, p, u.value)
 	default:
 		fmt.Fprintf(fs, "%%!%c(*Unit=%g)", c, u)
 		return


### PR DESCRIPTION
This updates behaviour to follow changes to fmt in
https://github.com/golang/go/commit/4e834cff4f7d4f736600d36d209ea6f388a44c44.

Changes to displayed precision in the test values are in line with how %f and %e work with plain float64 values.

@jonlawlor @btracey PTAL